### PR TITLE
Changed URL to use Ruby's standard URI regex

### DIFF
--- a/lib/scrivener/validations.rb
+++ b/lib/scrivener/validations.rb
@@ -1,4 +1,5 @@
 class Scrivener
+  require "uri"
 
   # Provides a base implementation for extensible validation routines.
   # {Scrivener::Validations} currently only provides the following assertions:
@@ -130,9 +131,7 @@ class Scrivener
       end
     end
 
-    URL = /\A(http|https):\/\/([a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}|(2
-          5[0-5]|2[0-4]\d|[0-1]?\d?\d)(\.(25[0-5]|2[0-4]\d|[0-1]?\d?\d)){3}
-          |localhost)(:[0-9]{1,5})?(\/.*)?\z/ix
+    URL = URI::regexp(%w(http https))
 
     def assert_url(att, error = [att, :not_url])
       if assert_present(att, error)

--- a/test/scrivener_test.rb
+++ b/test/scrivener_test.rb
@@ -115,6 +115,10 @@ scope do
 
     p = Post.new(url: "http://google.com", email: "me@google.com")
     assert p.valid?
+
+    # server name without a / but a ? is a valid URL
+    p = Post.new(url: "http://google.com?blah=blah", email: "me@google.com")
+    assert p.valid?
   end
 end
 


### PR DESCRIPTION
Removed custom URL regex and used standard regex provided by Ruby for more consistent URL matching. Test case included in test/scrivener_test.rb.
