### PR TITLE
Use #=== operator instead of #match to compare a regexp against a string...

### DIFF
--- a/lib/scrivener/validations.rb
+++ b/lib/scrivener/validations.rb
@@ -103,7 +103,7 @@ class Scrivener
     #                                when the validation fails.
     def assert_format(att, format, error = [att, :format])
       if assert_present(att, error)
-        assert(send(att).to_s.match(format), error)
+        assert(format === send(att).to_s, error)
       end
     end
 
@@ -174,9 +174,9 @@ class Scrivener
     # to make the case equality work, the check inverts the order of
     # the arguments: `assert_equal :foo, Bar` is translated to the
     # expression `Bar === send(:foo)`.
-    # 
+    #
     # @example
-    # 
+    #
     #   def validate
     #     assert_equal :status, "pending"
     #     assert_equal :quantity, Fixnum


### PR DESCRIPTION
....

It seems that performs better too. I ran this benchmark:

```ruby
require "scrivener/validations"

EMAIL = Scrivener::Validations::EMAIL

Benchmark.ips do |x|
  x.report("match") { "frodsan@me.com".match(EMAIL) } # => Object or nil
  x.report("=~")    { "frodsan@me.com" =~ EMAIL }     # => Integer or nil
  x.report("===")   { EMAIL === "frodsan@me.com" }    # => true or false
end
```

Results:

```
Calculating -------------------------------------
               match     17922 i/100ms
                  =~     22138 i/100ms
                 ===     24802 i/100ms
-------------------------------------------------
               match   249218.8 (±20.3%) i/s -    1182852 in   5.048778s
                  =~   388491.8 (±16.7%) i/s -    1903868 in   5.055993s
                 ===   430418.3 (±11.4%) i/s -    2132972 in   5.025354s
```