### PR TITLE
Remove assert_equal from SignUp readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,12 +135,10 @@ class SignUp < Scrivener
     assert_email :email
 
     if assert_present :password
-      assert_equal :password, :password_confirmation
-    end
-  end
+      assert(password == password_confirmation,
+             [:password_confirmation, :not_confirmed])
 
-  def assert_equal(f1, f2)
-    assert send(f1) == send(f2), [f1, f2, :not_equal]
+    end
   end
 end
 


### PR DESCRIPTION
This was a little confusing to me because the assert_equal defined
in the example didn't match the validation Scrivener defines.