### PR TITLE
Fix to README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ class SignUp < Scrivener
     assert_email :email
 
     if assert_present :password
-      assert_equal :password, :password_confirmation
+      assert_equal :password, password_confirmation
     end
   end
 end


### PR DESCRIPTION
This PR fixes Slice's section assert_equal example in README file.