### PR TITLE
Support for optional attributes

### DIFF
--- a/lib/scrivener.rb
+++ b/lib/scrivener.rb
@@ -35,6 +35,8 @@ class Scrivener
   #   post = Post.new(edit.attributes)
   #   post.save
   def initialize(atts)
+    @_accessors = atts.keys.map { |key| "#{key}=".to_sym }
+
     atts.each do |key, val|
       accessor = "#{key}="
 
@@ -45,7 +47,7 @@ class Scrivener
   end
 
   def _accessors
-    public_methods(false).select do |name|
+    @_accessors & public_methods(false).select do |name|
       name[-1] == "="
     end
   end

--- a/test/scrivener_test.rb
+++ b/test/scrivener_test.rb
@@ -20,6 +20,7 @@ scope do
     atts = { :a => 1 }
 
     assert filter = A.new(atts)
+    assert_equal filter.attributes, { :a => 1 }
   end
 
   test "return attributes" do


### PR DESCRIPTION
This commit introduces support for optional attributes. It avoids
silently assigning the value `nil` to attributes that are not
present in the original input, but are attributes of the validator
object

Consider the following, similar to the example in the README:

``` ruby
post.inspect
# => { :title => "The Original Title", :author => "britishtea" }

class UpdatePost < Scrivener
  attr_accessor :title
  attr_accessor :author

  def validate
    if assert_present :title
      assert_length :title, 3..150
    end
  end
end

input = UpdatePost.new({ :title => "A Changed Title" })
input.valid?
# => true
```

This is correct. No assertions for `:author` are made, so no errors
are expected. When using the output of `#attributes` however, data 
loss is very easy to occur.

``` ruby
post.update_attributes(input.attributes)
post.inspect
# => { :title => "A Changed Title", :author => nil }
```

That's because `#attributes` assigns `nil` for "missing" attributes.

``` ruby
input.attributes
# => { :title => "A Changed Title", :author => nil }
```

This commit changes `#attributes` to not assign `nil` to "missing"
attributes, so they become optional.

``` ruby
input.attributes
# => { :title => "A Changed Title" }
```

It's still possible to make assertions on optional attributes:

``` ruby
class UpdatePost < Scrivener
  attr_accessor :title
  attr_accessor :author

  def validate
    if assert_present :title
      assert_length :title, 3..150
    end

    if author
      assert_match :author, /[A-Z]\w+ [A-Z]\w+/
    end
  end
end
```

The change is subtle, but existing code might expect missing
attributes to be `nil. If it is to be merged, I think it's wise to
bump the version to 2.0.
