### PR TITLE
Validation error contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ body  = "I am a rather elderly man..."
 article = Article.new(title: title, body: body)
 
 article.valid?            #=> false
-article.errors[:state] #=> [:not_present]
+article.errors[:state] #=> [[:not_present]]
 ```
 
 Of course, what you would do instead is declare `:title` and `:body` as allowed
@@ -151,6 +151,13 @@ end
 By calling `slice` with a list of attributes, you get a hash with only
 those key/value pairs.
 
+Validation Errors
+-----------------
+
+Errors in a Scrivener assertion are meant to be a two-element Array, where the
+first element is an error code, and the second an optional context describing
+the failure.
+
 Assertions
 -----------
 
@@ -165,14 +172,14 @@ to false.
 
 ``` ruby
 def assert(value, error)
-   value or errors[error.first].push(error.last) && false
+  value or errors[error.first].push(error.last) && false
 end
 ```
 
 ### assert_present
 
 Checks that the given field is not nil or empty. The error code for this
-assertion is `:not_present`.
+assertion is `:not_present`, with no context.
 
 ### assert_equal
 
@@ -182,28 +189,34 @@ make the case equality work, the check inverts the order of the
 arguments: `assert_equal :foo, Bar` is translated to the expression
 `Bar === send(:foo)`.
 
+The error code for this assertion is `:not_equal`. The context is the
+value you passed for checking, so `assrt_equal :foo, Bar` would return
+a `[:not_equal, Bar]` error.
+
 ### assert_format
 
 Checks that the given field matches the provided regular expression.
-The error code for this assertion is `:format`.
+The error code for this assertion is `:format`, and the context the regular
+expression.
 
 ### assert_numeric
 
 Checks that the given field holds a number as a Fixnum or as a string
-representation. The error code for this assertion is `:not_numeric`.
+representation. The error code for this assertion is `:not_numeric`, with no
+context.
 
 ### assert_url
 
 Provides a pretty general URL regular expression match. An important
 point to make is that this assumes that the URL should start with
 `http://` or `https://`. The error code for this assertion is
-`:not_url`.
+`:not_url`, with no context..
 
 ### assert_email
 
 In this current day and age, almost all web applications need to
 validate an email address. This pretty much matches 99% of the emails
-out there. The error code for this assertion is `:not_email`.
+out there. The error code for this assertion is `:not_email`, with no context.
 
 ### assert_member
 
@@ -216,7 +229,8 @@ def validate
 end
 ```
 
-The error code for this assertion is `:not_valid`
+The error code for this assertion is `:not_valid`, and the context the set of
+vlid values.
 
 ### assert_length
 
@@ -228,14 +242,15 @@ def validate
 end
 ```
 
-The error code for this assertion is `:not_in_range`.
+The error code for this assertion is `:not_in_range`, and the context the range
+of valid lengths.
 
 ### assert_decimal
 
 Checks that a given field looks like a number in the human sense
 of the word. Valid numbers are: 0.1, .1, 1, 1.1, 3.14159, etc.
 
-The error code for this assertion is `:not_decimal`.
+The error code for this assertion is `:not_decimal`, with no context.
 
 Installation
 ------------

--- a/lib/scrivener/validations.rb
+++ b/lib/scrivener/validations.rb
@@ -44,9 +44,9 @@ class Scrivener
   #   # => false
   #
   #   s.errors
-  #   # => { :title => [:not_present],
-  #          :price => [:not_numeric],
-  #          :date  => [:format] }
+  #   # => { :title => [[:not_present]],
+  #          :price => [[:not_numeric]],
+  #          :date  => [[:format, /\A[\d]{4}-[\d]{1,2}-[\d]{1,2}\z] }
   #
   module Validations
 
@@ -92,9 +92,10 @@ class Scrivener
     # @param [Symbol] att The attribute you want to verify the format of.
     # @param [Regexp] format The regular expression with which to compare
     #                 the value of att with.
-    # @param [Array<Symbol, Symbol>] error The error that should be returned
-    #                                when the validation fails.
-    def assert_format(att, format, error = [att, :format])
+    # @param [Array<Symbol, Array<Symbol, Object>>] error The error that should
+    #                                               be returned when the
+    #                                               validation fails.
+    def assert_format(att, format, error = [att, [:format, format]])
       if assert_present(att, error)
         assert(send(att).to_s.match(format), error)
       end
@@ -104,18 +105,20 @@ class Scrivener
     # value of the attribute is empty.
     #
     # @param [Symbol] att The attribute you wish to verify the presence of.
-    # @param [Array<Symbol, Symbol>] error The error that should be returned
-    #                                when the validation fails.
-    def assert_present(att, error = [att, :not_present])
+    # @param [Array<Symbol, Array<Symbol, Object>>] error The error that should
+    #                                               be returned when the
+    #                                               validation fails.
+    def assert_present(att, error = [att, [:not_present]])
       assert(!send(att).to_s.empty?, error)
     end
 
     # Checks if all the characters of an attribute is a digit.
     #
     # @param [Symbol] att The attribute you wish to verify the numeric format.
-    # @param [Array<Symbol, Symbol>] error The error that should be returned
-    #                                when the validation fails.
-    def assert_numeric(att, error = [att, :not_numeric])
+    # @param [Array<Symbol, Array<Symbol, Object>>] error The error that should
+    #                                               be returned when the
+    #                                               validation fails.
+    def assert_numeric(att, error = [att, [:not_numeric]])
       if assert_present(att, error)
         assert_format(att, /\A\-?\d+\z/, error)
       end
@@ -125,7 +128,7 @@ class Scrivener
           5[0-5]|2[0-4]\d|[0-1]?\d?\d)(\.(25[0-5]|2[0-4]\d|[0-1]?\d?\d)){3}
           |localhost)(:[0-9]{1,5})?(\/.*)?\z/ix
 
-    def assert_url(att, error = [att, :not_url])
+    def assert_url(att, error = [att, [:not_url]])
       if assert_present(att, error)
         assert_format(att, URL, error)
       end
@@ -136,17 +139,17 @@ class Scrivener
             ((((([a-z0-9]{1}[a-z0-9\-]{0,62}[a-z0-9]{1})|[a-z])\.)+
             [a-z]{2,12})|(\d{1,3}\.){3}\d{1,3}(\:\d{1,5})?)\z/ix
 
-    def assert_email(att, error = [att, :not_email])
+    def assert_email(att, error = [att, [:not_email]])
       if assert_present(att, error)
         assert_format(att, EMAIL, error)
       end
     end
 
-    def assert_member(att, set, err = [att, :not_valid])
+    def assert_member(att, set, err = [att, [:not_valid, set]])
       assert(set.include?(send(att)), err)
     end
 
-    def assert_length(att, range, error = [att, :not_in_range])
+    def assert_length(att, range, error = [att, [:not_in_range, range]])
       if assert_present(att, error)
         val = send(att).to_s
         assert range.include?(val.length), error
@@ -155,7 +158,7 @@ class Scrivener
 
     DECIMAL = /\A\-?(\d+)?(\.\d+)?\z/
 
-    def assert_decimal(att, error = [att, :not_decimal])
+    def assert_decimal(att, error = [att, [:not_decimal]])
       assert_format att, DECIMAL, error
     end
 
@@ -174,9 +177,10 @@ class Scrivener
     #
     # @param [Symbol] att The attribute you wish to verify for equality.
     # @param [Object] value The value you want to test against.
-    # @param [Array<Symbol, Symbol>] error The error that should be returned
-    #                                when the validation fails.
-    def assert_equal(att, value, error = [att, :not_equal])
+    # @param [Array<Symbol, Array<Symbol, Object>>] error The error that should
+    #                                               be returned when the
+    #                                               validation fails.
+    def assert_equal(att, value, error = [att, [:not_equal, value]])
       assert value === send(att), error
     end
 


### PR DESCRIPTION
Introduce the notion of errors giving some context into why the validation failed. Fixes https://github.com/soveran/scrivener/issues/22

This change breaks backwards compatibility.