### PR TITLE
Correct typo, improve style in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,13 +218,13 @@ In a wizard, different model states ask for different validations,
 and a single set of validations for the whole process is not the
 best solution.
 
-This library exists to satify the need of extracting
+This library exists to satisfy the need for extracting
 [Ohm](http://ohm.keyvalue.org)'s validations for reuse in other
 scenarios.
 
 Using Scrivener feels very natural no matter what underlying model
 you are using. As it provides its own validation and whitelisting
-features, you can choose to ignore the ones that come bundled with
+features, you can choose to ignore those that come bundled with
 ORMs.
 
 See also


### PR DESCRIPTION
I like the new flow of the README! The Usage section is much clearer. Thank you.

When reading through I spotted a couple of minor issues, addressed in this PR:

- `s/satify/satisfy/` (typo)
- `s/the ones/those/` (style)
- `s/the need of extracting/the need for extracting/` (style)

The last change is debatable, I’m going off gut feeling. An analysis can be found here:
https://english.stackexchange.com/questions/6623/need-of-vs-need-for

If you wish to reject the last change I can recreate the PR with the first two only.