### PR TITLE
Fix example for the password confirmation use case

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ class CreateUser < Scrivener
     assert_email :email
 
     if assert_present :password
-      assert_equal :password, :password_confirmation
+      assert_equal :password, password_confirmation
     end
   end
 end


### PR DESCRIPTION
There's a spare `:` on the password confirmation example in the readme. Might led to think the method also accepts 2 symbols as valid arguments (which will most probably end up in a filter that is never valid)