### PR TITLE
Allow passing arguments to Scrivener#validate

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,33 @@ if filter.valid?
 end
 ```
 
+Sometimes we might want to use parameters from the outside for validation,
+but don't want the validator to treat them as attributes. In that case we
+can pass arguments to `#valid?`, and they will be forwarded to `#validate`.
+
+```ruby
+class CreateComment < Scrivener
+  attr_accessor :content
+  attr_accessor :article_id
+
+  def validate(available_articles:)
+    assert_present :content
+    assert_member :article_id, available_articles.map(&:id)
+  end
+end
+```
+
+```ruby
+params = {
+  content:    "this is a comment",
+  article_id: 57,
+}
+
+filter = CreateComment.new(params)
+
+filter.valid?(available_articles: user.articles)
+```
+
 Assertions
 -----------
 

--- a/lib/scrivener/validations.rb
+++ b/lib/scrivener/validations.rb
@@ -67,14 +67,14 @@ class Scrivener
     #     end
     #   end
     #
-    def valid?
+    def valid?(*args)
       errors.clear
-      validate
+      validate(*args)
       errors.empty?
     end
 
     # Base validate implementation. Override this method in subclasses.
-    def validate
+    def validate(*args)
     end
 
     # Hash of errors for each attribute in this model.

--- a/test/scrivener_test.rb
+++ b/test/scrivener_test.rb
@@ -280,3 +280,24 @@ scope do
     assert_equal errors, j2.errors
   end
 end
+
+class K < Scrivener
+  def validate(argument)
+    assert argument == "K", [:k, :not_valid]
+  end
+end
+
+scope do
+  test "passing arguments" do
+    k = K.new({})
+
+    assert_equal true,  k.valid?("K")
+    assert_equal false, k.valid?("L")
+
+    errors = {
+      k: [:not_valid]
+    }
+
+    assert_equal errors, k.errors
+  end
+end


### PR DESCRIPTION
Hello 👋 

We have a use case where we're creating a record, but want to verify that "foreign key" fields match existing records. We're currently making these queries in the validator, but I would now like to remove N+1 queries, so I would like to pass the list of already loaded associated records to the validator.

I don't want to pass those as validator attributes, because they didn't come from the user, and I would have to exclude them when calling `Scrivener#attributes`. So I thought it would be useful if I can pass these values to `#validate` via `#valid?`, and that's what this pull request does.