### PR TITLE
Avoid warning when forwarding arguments to #validate

### DIFF
--- a/lib/scrivener/validations.rb
+++ b/lib/scrivener/validations.rb
@@ -67,14 +67,14 @@ class Scrivener
     #     end
     #   end
     #
-    def valid?(*args)
+    def valid?(*args, **kargs)
       errors.clear
-      validate(*args)
+      validate(*args, **kargs)
       errors.empty?
     end
 
     # Base validate implementation. Override this method in subclasses.
-    def validate(*args)
+    def validate(*args, **kargs)
     end
 
     # Hash of errors for each attribute in this model.

--- a/test/scrivener_test.rb
+++ b/test/scrivener_test.rb
@@ -301,3 +301,24 @@ scope do
     assert_equal errors, k.errors
   end
 end
+
+class L < Scrivener
+  def validate(argument, key:)
+    assert argument == "L" && key == "L", [:l, :not_valid]
+  end
+end
+
+scope do
+  test "passing keyword arguments" do
+    l = L.new({})
+
+    assert_equal true,  l.valid?("L", key: "L")
+    assert_equal false, l.valid?("M", key: "M")
+
+    errors = {
+      l: [:not_valid]
+    }
+
+    assert_equal errors, l.errors
+  end
+end


### PR DESCRIPTION
This avoids ruby 2.7 warning when passing keyword arguments to "valid?". This
way, we can still pass positional arguments as well as keyword arguments.

Fix #28 